### PR TITLE
Update definition.md

### DIFF
--- a/fenxu_docs_20160719/definition.md
+++ b/fenxu_docs_20160719/definition.md
@@ -12,6 +12,4 @@
 
 
 1. [google in list]: https://google.com
-   The above is definition for google
 2. [bing in list]: https://bing.com
-   The above is definition for bing


### PR DESCRIPTION
Why would you want to put link definitions in a list?  When link definitions are not part of a list, they do not render.  But if they are the only thing in a list, then the list renders as a empty list, which you probably do not want.